### PR TITLE
Feat: Spring Boot 채팅 서버 초기 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Gradle
+.gradle/
+build/
+out/
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,35 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("org.springframework.boot") version "3.1.4"
+    id("io.spring.dependency-management") version "1.1.3"
+    kotlin("jvm") version "1.9.10"
+    kotlin("plugin.spring") version "1.9.10"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_17
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "17"
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "mini-discord"

--- a/src/main/kotlin/com/example/chat/ChatApplication.kt
+++ b/src/main/kotlin/com/example/chat/ChatApplication.kt
@@ -1,0 +1,11 @@
+package com.example.chat
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class ChatApplication
+
+fun main(args: Array<String>) {
+    runApplication<ChatApplication>(*args)
+}

--- a/src/main/kotlin/com/example/chat/ChatWebSocketHandler.kt
+++ b/src/main/kotlin/com/example/chat/ChatWebSocketHandler.kt
@@ -1,0 +1,11 @@
+package com.example.chat
+
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.handler.TextWebSocketHandler
+
+class ChatWebSocketHandler : TextWebSocketHandler() {
+    override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
+        session.sendMessage(TextMessage(message.payload))
+    }
+}

--- a/src/main/kotlin/com/example/chat/HomeController.kt
+++ b/src/main/kotlin/com/example/chat/HomeController.kt
@@ -1,0 +1,39 @@
+package com.example.chat
+
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HomeController {
+    @GetMapping("/", produces = [MediaType.TEXT_HTML_VALUE])
+    fun index() = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset=\"UTF-8\"/>
+            <title>Chat</title>
+            <script>
+                let ws;
+                function connect() {
+                    ws = new WebSocket('ws://' + location.host + '/ws/chat');
+                    ws.onmessage = function(e) {
+                        const log = document.getElementById('log');
+                        log.value += e.data + '\n';
+                    };
+                }
+                function sendMsg() {
+                    const input = document.getElementById('msg');
+                    ws.send(input.value);
+                    input.value = '';
+                }
+            </script>
+        </head>
+        <body onload=\"connect()\">
+            <textarea id=\"log\" rows=\"10\" cols=\"40\" readonly></textarea><br/>
+            <input id=\"msg\" type=\"text\"/>
+            <button onclick=\"sendMsg()\">send</button>
+        </body>
+        </html>
+    """.trimIndent()
+}

--- a/src/main/kotlin/com/example/chat/WebSocketConfig.kt
+++ b/src/main/kotlin/com/example/chat/WebSocketConfig.kt
@@ -1,0 +1,18 @@
+package com.example.chat
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.socket.config.annotation.EnableWebSocket
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
+
+@Configuration
+@EnableWebSocket
+class WebSocketConfig : WebSocketConfigurer {
+    override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
+        registry.addHandler(chatWebSocketHandler(), "/ws/chat").setAllowedOrigins("*")
+    }
+
+    @Bean
+    fun chatWebSocketHandler() = ChatWebSocketHandler()
+}


### PR DESCRIPTION
## Summary
- Spring Boot 3.1.4 기반 Gradle 설정 추가
- 기본 애플리케이션과 웹소켓 핸들러 구현
- 웹소켓 엔드포인트 `/ws/chat` 과 테스트용 HTML 제공
- 불필요한 빌드 산출물 제외를 위해 `.gitignore` 수정

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_684b886bfb1c8322a08ce15072f77c52