### PR TITLE
Feat: add Dockerfile for jar deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.dockerignore
+Dockerfile
+.git
+.gitignore
+.gradle
+build
+out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY build/libs/*.jar /app/app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
## Summary
- Dockerfile에서 build/libs 경로의 jar를 `/app/app.jar`로 복사
- 실행 명령을 ENTRYPOINT로 설정
- 빌드 캐시가 제외되도록 `.dockerignore` 추가

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684ba32125ac832288c1dea325b12671