### PR TITLE
Add: Redis Deployment 및 서비스

### DIFF
--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:latest
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: /data
+              name: redis-data
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- k8s/redis.yaml 파일에 Redis PVC, Deployment, Service 정의를 추가했습니다.
- 레플리카 1개와 포트 6379 노출, 저장소는 PVC 예시를 포함했습니다.

## Testing
- `gradle test` 실행하여 빌드가 성공하는 것을 확인했습니다.

------
https://chatgpt.com/codex/tasks/task_e_684ba85862fc8322883617ab25d29ac0