### PR TITLE
Add: chat service yaml for NodePort

### DIFF
--- a/k8s/chat-service.yaml
+++ b/k8s/chat-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: chat
+spec:
+  type: NodePort
+  selector:
+    app: chat
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30080 # NodePort 범위 예시: 30000-32767


### PR DESCRIPTION
## Summary
- chat 서비스용 NodePort 타입 Service 작성

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684baaba25708322ab2c351f988de085