### PR TITLE
Feat: add load test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Mini-Discord
 쿠버네티스 실습을 위한 미니 디스코드 프로젝트
+
+## 부하 테스트 스크립트
+WebSocket 연결 부하 테스트용 `scripts/load-test.sh` 파일을 제공합니다. 사용 전 실행 권한을 부여하세요.
+
+```bash
+chmod +x scripts/load-test.sh
+```
+
+`REDIS_HOST`와 `PORT` 환경 변수를 지정하면 접속할 서버를 변경할 수 있습니다.

--- a/scripts/load-test.sh
+++ b/scripts/load-test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# 1분 동안 100개의 WebSocket 연결을 유지하며 1초마다 메시지를 전송합니다.
+
+set -euo pipefail
+
+REDIS_HOST="${REDIS_HOST:-localhost}"
+PORT="${PORT:-8080}"
+
+for i in $(seq 1 100); do
+  (
+    for j in $(seq 1 60); do
+      echo "load test $i $j"
+      sleep 1
+    done
+  ) | websocat "ws://$REDIS_HOST:$PORT/ws/chat" >/dev/null &
+done
+
+wait


### PR DESCRIPTION
## Summary
- WebSocket 부하 테스트용 `scripts/load-test.sh` 추가
- README에 스크립트 권한 설정 예시 및 환경 변수 설명 추가

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684bb258a1308322813f5817e21ec5f5