### PR TITLE
Fix: update chat service selector

### DIFF
--- a/k8s/chat-service.yaml
+++ b/k8s/chat-service.yaml
@@ -3,9 +3,10 @@ kind: Service
 metadata:
   name: chat
 spec:
+  # NodePort 타입을 사용하여 외부 접근을 허용합니다.
   type: NodePort
   selector:
-    app: chat
+    app: mini-discord-chat
   ports:
     - port: 8080
       targetPort: 8080


### PR DESCRIPTION
## Summary
- 서비스 selector를 배포 설정에 맞게 수정
- NodePort 사용을 명확히 설명하는 주석 추가

## Testing
- `gradlew` 스크립트가 없어 테스트를 실행하지 못함

------
https://chatgpt.com/codex/tasks/task_e_684bb779c1d08322b8767997474aff28