### PR TITLE
Refactor: rename load-test variable to WS_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ WebSocket 연결 부하 테스트용 `scripts/load-test.sh` 파일을 제공합�
 chmod +x scripts/load-test.sh
 ```
 
-`REDIS_HOST`와 `PORT` 환경 변수를 지정하면 접속할 서버를 변경할 수 있습니다.
+`WS_HOST`와 `PORT` 환경 변수를 지정하면 접속할 서버를 변경할 수 있습니다.
 

--- a/scripts/load-test.sh
+++ b/scripts/load-test.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-REDIS_HOST="${REDIS_HOST:-localhost}"
+WS_HOST="${WS_HOST:-localhost}"
 PORT="${PORT:-8080}"
 
 for i in $(seq 1 100); do
@@ -12,7 +12,7 @@ for i in $(seq 1 100); do
       echo "load test $i $j"
       sleep 1
     done
-  ) | websocat "ws://$REDIS_HOST:$PORT/ws/chat" >/dev/null &
+  ) | websocat "ws://$WS_HOST:$PORT/ws/chat" >/dev/null &
 done
 
 wait


### PR DESCRIPTION
## Summary
- `load-test.sh` 변수명을 `WS_HOST`로 수정
- README의 설명도 동일하게 변경

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_684bb77a36e08322b476d7547170e3ec